### PR TITLE
Fix issue #515

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -985,8 +985,17 @@ class Request extends EventEmitter {
 
     for (let index = 0; index < values.length; index++) {
       let value = values[index]
-      this.input(`param${index + 1}`, value)
-      command.push(`@param${index + 1}`, strings[index + 1])
+      if (Array.isArray(value)) {//if value is an array, prepare each items and add a coma between each item
+        for (let arrayIndex = 0; arrayIndex < value.length - 1; arrayIndex++) {
+          this.input(`param${index + 1}_${arrayIndex}`, value[arrayIndex])
+          command.push(`@param${index + 1}_${arrayIndex}`, ',')
+        }
+        this.input(`param${index + 1}_${value.length - 1}`, value[value.length - 1])
+        command.push(`@param${index + 1}_${value.length - 1}`, strings[index + 1])
+      } else {
+        this.input(`param${index + 1}`, value)
+        command.push(`@param${index + 1}`, strings[index + 1])
+      }
     }
 
     return this[method](command.join(''))


### PR DESCRIPTION
When passing an array to a string litteral template, each item of this array is prepared.

This let you do as follow :

connector.query`SELECT * FROM table WHERE name in (${array})`

Instead of :

connector.query`SELECT * FROM table WHERE name in (${array[0]},${array[1]},${array[2]}...)`
connector.query`SELECT * FROM table WHERE name in (${array.map((v, i) => `@array${i}`).join(', ')})`